### PR TITLE
fix: remove typing optional union

### DIFF
--- a/src/uipath/dev/_demo/mock_context_runtime.py
+++ b/src/uipath/dev/_demo/mock_context_runtime.py
@@ -1,6 +1,6 @@
 import asyncio
 import logging
-from typing import Any, AsyncGenerator, Optional
+from typing import Any, AsyncGenerator
 
 from opentelemetry import trace
 from uipath.runtime import (
@@ -57,8 +57,8 @@ class MockContextRuntime:
 
     async def execute(
         self,
-        input: Optional[dict[str, Any]] = None,
-        options: Optional[UiPathExecuteOptions] = None,
+        input: dict[str, Any] | None = None,
+        options: UiPathExecuteOptions | None = None,
     ) -> UiPathRuntimeResult:
         from uipath.runtime.debug import UiPathBreakpointResult
 
@@ -451,8 +451,8 @@ class MockContextRuntime:
 
     async def stream(
         self,
-        input: Optional[dict[str, Any]] = None,
-        options: Optional[UiPathStreamOptions] = None,
+        input: dict[str, Any] | None = None,
+        options: UiPathStreamOptions | None = None,
     ) -> AsyncGenerator[UiPathRuntimeEvent, None]:
         logger.info("MockRuntime: stream() invoked")
         print("[MockRuntime] stream() invoked")

--- a/src/uipath/dev/_demo/mock_greeting_runtime.py
+++ b/src/uipath/dev/_demo/mock_greeting_runtime.py
@@ -1,6 +1,6 @@
 import asyncio
 import logging
-from typing import Any, AsyncGenerator, Optional
+from typing import Any, AsyncGenerator
 
 from opentelemetry import trace
 from uipath.runtime import (
@@ -59,8 +59,8 @@ class MockGreetingRuntime:
 
     async def execute(
         self,
-        input: Optional[dict[str, Any]] = None,
-        options: Optional[UiPathExecuteOptions] = None,
+        input: dict[str, Any] | None = None,
+        options: UiPathExecuteOptions | None = None,
     ) -> UiPathRuntimeResult:
         payload = input or {}
         name = str(payload.get("name", "world")).strip() or "world"
@@ -121,8 +121,8 @@ class MockGreetingRuntime:
 
     async def stream(
         self,
-        input: Optional[dict[str, Any]] = None,
-        options: Optional[UiPathStreamOptions] = None,
+        input: dict[str, Any] | None = None,
+        options: UiPathStreamOptions | None = None,
     ) -> AsyncGenerator[UiPathRuntimeEvent, None]:
         logger.info("GreetingRuntime: stream() invoked")
         yield await self.execute(input=input, options=options)

--- a/src/uipath/dev/_demo/mock_numbers_runtime.py
+++ b/src/uipath/dev/_demo/mock_numbers_runtime.py
@@ -1,6 +1,6 @@
 import asyncio
 import logging
-from typing import Any, AsyncGenerator, Optional
+from typing import Any, AsyncGenerator
 
 from opentelemetry import trace
 from uipath.runtime import (
@@ -58,8 +58,8 @@ class MockNumberAnalyticsRuntime:
 
     async def execute(
         self,
-        input: Optional[dict[str, Any]] = None,
-        options: Optional[UiPathExecuteOptions] = None,
+        input: dict[str, Any] | None = None,
+        options: UiPathExecuteOptions | None = None,
     ) -> UiPathRuntimeResult:
         payload = input or {}
         numbers = payload.get("numbers") or []
@@ -134,8 +134,8 @@ class MockNumberAnalyticsRuntime:
 
     async def stream(
         self,
-        input: Optional[dict[str, Any]] = None,
-        options: Optional[UiPathStreamOptions] = None,
+        input: dict[str, Any] | None = None,
+        options: UiPathStreamOptions | None = None,
     ) -> AsyncGenerator[UiPathRuntimeEvent, None]:
         logger.info("NumberAnalyticsRuntime: stream() invoked")
         yield await self.execute(input=input, options=options)

--- a/src/uipath/dev/_demo/mock_support_runtime.py
+++ b/src/uipath/dev/_demo/mock_support_runtime.py
@@ -1,6 +1,6 @@
 import asyncio
 import logging
-from typing import Any, AsyncGenerator, Optional
+from typing import Any, AsyncGenerator
 
 from opentelemetry import trace
 from uipath.runtime import (
@@ -57,8 +57,8 @@ class MockSupportChatRuntime:
 
     async def execute(
         self,
-        input: Optional[dict[str, Any]] = None,
-        options: Optional[UiPathExecuteOptions] = None,
+        input: dict[str, Any] | None = None,
+        options: UiPathExecuteOptions | None = None,
     ) -> UiPathRuntimeResult:
         payload = input or {}
         message = str(payload.get("message", "")).strip()
@@ -136,8 +136,8 @@ class MockSupportChatRuntime:
 
     async def stream(
         self,
-        input: Optional[dict[str, Any]] = None,
-        options: Optional[UiPathStreamOptions] = None,
+        input: dict[str, Any] | None = None,
+        options: UiPathStreamOptions | None = None,
     ) -> AsyncGenerator[UiPathRuntimeEvent, None]:
         logger.info("SupportChatRuntime: stream() invoked")
         yield await self.execute(input=input, options=options)

--- a/src/uipath/dev/models/execution.py
+++ b/src/uipath/dev/models/execution.py
@@ -2,7 +2,7 @@
 
 import os
 from datetime import datetime
-from typing import Any, Optional, Union
+from typing import Any
 from uuid import uuid4
 
 from rich.text import Text
@@ -17,7 +17,7 @@ class ExecutionRun:
     def __init__(
         self,
         entrypoint: str,
-        input_data: Union[dict[str, Any]],
+        input_data: dict[str, Any],
         conversational: bool = False,
         debug: bool = False,
     ):
@@ -27,14 +27,14 @@ class ExecutionRun:
         self.input_data = input_data
         self.conversational = conversational
         self.debug = debug
-        self.resume_data: Optional[dict[str, Any]] = None
-        self.output_data: Optional[dict[str, Any]] = None
+        self.resume_data: dict[str, Any] | None = None
+        self.output_data: dict[str, Any] | None = None
         self.start_time = datetime.now()
-        self.end_time: Optional[datetime] = None
+        self.end_time: datetime | None = None
         self.status = "pending"  # pending, running, completed, failed, suspended
         self.traces: list[TraceMessage] = []
         self.logs: list[LogMessage] = []
-        self.error: Optional[UiPathErrorContract] = None
+        self.error: UiPathErrorContract | None = None
 
     @property
     def duration(self) -> str:

--- a/src/uipath/dev/models/messages.py
+++ b/src/uipath/dev/models/messages.py
@@ -1,7 +1,7 @@
 """Messages used for inter-component communication in the UiPath Developer Console."""
 
 from datetime import datetime
-from typing import Any, Optional, Union
+from typing import Any
 
 from rich.console import RenderableType
 from textual.message import Message
@@ -14,8 +14,8 @@ class LogMessage(Message):
         self,
         run_id: str,
         level: str,
-        message: Union[str, RenderableType],
-        timestamp: Optional[datetime] = None,
+        message: str | RenderableType,
+        timestamp: datetime | None = None,
     ):
         """Initialize a LogMessage instance."""
         self.run_id = run_id
@@ -33,12 +33,12 @@ class TraceMessage(Message):
         run_id: str,
         span_name: str,
         span_id: str,
-        parent_span_id: Optional[str] = None,
-        trace_id: Optional[str] = None,
+        parent_span_id: str | None = None,
+        trace_id: str | None = None,
         status: str = "running",
-        duration_ms: Optional[float] = None,
-        timestamp: Optional[datetime] = None,
-        attributes: Optional[dict[str, Any]] = None,
+        duration_ms: float | None = None,
+        timestamp: datetime | None = None,
+        attributes: dict[str, Any] | None = None,
     ):
         """Initialize a TraceMessage instance."""
         self.run_id = run_id

--- a/src/uipath/dev/services/debug_bridge.py
+++ b/src/uipath/dev/services/debug_bridge.py
@@ -2,7 +2,7 @@
 
 import asyncio
 import logging
-from typing import Any, Callable, Literal, Optional
+from typing import Any, Callable, Literal
 
 from uipath.runtime.debug import UiPathBreakpointResult, UiPathDebugQuitError
 from uipath.runtime.events import UiPathRuntimeStateEvent
@@ -22,15 +22,11 @@ class TextualDebugBridge:
         self._breakpoints: list[str] | Literal["*"] = "*"  # Default: step mode
 
         # Callbacks to UI
-        self.on_execution_started: Optional[Callable[[], None]] = None
-        self.on_state_update: Optional[Callable[[UiPathRuntimeStateEvent], None]] = None
-        self.on_breakpoint_hit: Optional[Callable[[UiPathBreakpointResult], None]] = (
-            None
-        )
-        self.on_execution_completed: Optional[Callable[[UiPathRuntimeResult], None]] = (
-            None
-        )
-        self.on_execution_error: Optional[Callable[[str], None]] = None
+        self.on_execution_started: Callable[[], None] | None = None
+        self.on_state_update: Callable[[UiPathRuntimeStateEvent], None] | None = None
+        self.on_breakpoint_hit: Callable[[UiPathBreakpointResult], None] | None = None
+        self.on_execution_completed: Callable[[UiPathRuntimeResult], None] | None = None
+        self.on_execution_error: Callable[[str], None] | None = None
 
     async def connect(self) -> None:
         """Establish connection to debugger."""

--- a/src/uipath/dev/services/run_service.py
+++ b/src/uipath/dev/services/run_service.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import traceback
 from datetime import datetime
-from typing import Any, Callable, Dict, Optional
+from typing import Any, Callable
 
 from pydantic import BaseModel
 from uipath.core.tracing import UiPathTraceManager
@@ -40,14 +40,14 @@ class RunService:
         self,
         runtime_factory: UiPathRuntimeFactoryProtocol,
         trace_manager: UiPathTraceManager,
-        on_run_updated: Optional[RunUpdatedCallback] = None,
-        on_log: Optional[LogCallback] = None,
-        on_trace: Optional[TraceCallback] = None,
+        on_run_updated: RunUpdatedCallback | None = None,
+        on_log: LogCallback | None = None,
+        on_trace: TraceCallback | None = None,
     ) -> None:
         """Initialize RunService with runtime factory and trace manager."""
         self.runtime_factory = runtime_factory
         self.trace_manager = trace_manager
-        self.runs: Dict[str, ExecutionRun] = {}
+        self.runs: dict[str, ExecutionRun] = {}
 
         self.on_run_updated = on_run_updated
         self.on_log = on_log
@@ -68,7 +68,7 @@ class RunService:
         self.runs[run.id] = run
         self._emit_run_updated(run)
 
-    def get_run(self, run_id: str) -> Optional[ExecutionRun]:
+    def get_run(self, run_id: str) -> ExecutionRun | None:
         """Get a registered run."""
         return self.runs.get(run_id)
 
@@ -78,7 +78,7 @@ class RunService:
         This is the extracted version of the old `_execute_runtime` method.
         """
         try:
-            execution_input: Optional[dict[str, Any]] = {}
+            execution_input: dict[str, Any] | None = {}
             execution_options: UiPathExecuteOptions = UiPathExecuteOptions()
 
             if run.status == "suspended":
@@ -239,7 +239,7 @@ class RunService:
         if self.on_trace is not None:
             self.on_trace(trace_msg)
 
-    def get_debug_bridge(self, run_id: str) -> Optional[TextualDebugBridge]:
+    def get_debug_bridge(self, run_id: str) -> TextualDebugBridge | None:
         """Get the debug bridge for a run."""
         return self.debug_bridges.get(run_id)
 

--- a/src/uipath/dev/ui/panels/new_run_panel.py
+++ b/src/uipath/dev/ui/panels/new_run_panel.py
@@ -1,7 +1,7 @@
 """Panel for creating new runs with entrypoint selection and JSON input."""
 
 import json
-from typing import Any, Dict, Tuple, cast
+from typing import Any, Tuple, cast
 
 from textual.app import ComposeResult
 from textual.containers import Container, Horizontal, Vertical
@@ -96,7 +96,7 @@ class NewRunPanel(Container):
 
         self.entrypoints: list[str] = []
 
-        self.entrypoint_schemas: Dict[str, dict[str, Any]] = {}
+        self.entrypoint_schemas: dict[str, dict[str, Any]] = {}
 
         self.conversational: bool = False
         self.initial_input: str = "{}"

--- a/src/uipath/dev/ui/panels/run_details_panel.py
+++ b/src/uipath/dev/ui/panels/run_details_panel.py
@@ -1,7 +1,5 @@
 """Panel for displaying execution run details, traces, and logs."""
 
-from typing import Optional
-
 from textual.app import ComposeResult
 from textual.containers import Container, Horizontal, Vertical
 from textual.reactive import reactive
@@ -82,7 +80,7 @@ class SpanDetailsDisplay(Container):
 class RunDetailsPanel(Container):
     """Panel showing traces and logs for selected run with tabbed interface."""
 
-    current_run: reactive[Optional[ExecutionRun]] = reactive(None)
+    current_run: reactive[ExecutionRun | None] = reactive(None)
 
     def __init__(self, **kwargs):
         """Initialize RunDetailsPanel."""
@@ -145,7 +143,7 @@ class RunDetailsPanel(Container):
                 )
 
     def watch_current_run(
-        self, old_value: Optional[ExecutionRun], new_value: Optional[ExecutionRun]
+        self, old_value: ExecutionRun | None, new_value: ExecutionRun | None
     ):
         """Watch for changes to the current run."""
         if new_value is not None:

--- a/src/uipath/dev/ui/panels/run_history_panel.py
+++ b/src/uipath/dev/ui/panels/run_history_panel.py
@@ -1,7 +1,5 @@
 """Panel for displaying execution run history."""
 
-from typing import List, Optional
-
 from rich.text import Text
 from textual.app import ComposeResult
 from textual.containers import Container, Vertical
@@ -23,8 +21,8 @@ class RunHistoryPanel(Container):
     def __init__(self, **kwargs):
         """Initialize RunHistoryPanel with empty run list."""
         super().__init__(**kwargs)
-        self.runs: List[ExecutionRun] = []
-        self.selected_run: Optional[ExecutionRun] = None
+        self.runs: list[ExecutionRun] = []
+        self.selected_run: ExecutionRun | None = None
 
     def compose(self) -> ComposeResult:
         """Compose the RunHistoryPanel layout."""
@@ -57,7 +55,7 @@ class RunHistoryPanel(Container):
                 break
         # If run not found, just ignore; creation is done via add_run()
 
-    def get_run_by_id(self, run_id: str) -> Optional[ExecutionRun]:
+    def get_run_by_id(self, run_id: str) -> ExecutionRun | None:
         """Get a run."""
         for run in self.runs:
             if run.id == run_id:


### PR DESCRIPTION
## Description

This PR modernizes type hints by replacing the older `Optional[T]` and `Union[A, B]` syntax with the newer PEP 604 pipe union syntax (`T | None` and `A | B`). This change improves code readability and aligns with modern Python typing conventions (Python 3.10+).