### PR TITLE
Add TestPyPI configuration to pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -107,3 +107,8 @@ show_missing = true
 [tool.coverage.run]
 source = ["src"]
 
+[[tool.uv.index]]
+name = "testpypi"
+url = "https://test.pypi.org/simple/"
+publish-url = "https://test.pypi.org/legacy/"
+explicit = true


### PR DESCRIPTION
## Development Package

- Add this package as a dependency in your pyproject.toml:

```toml
[project]
dependencies = [
  # Exact version:
  "uipath-dev==0.0.7.dev1000190039",

  # Any version from PR
  "uipath-dev>=0.0.7.dev1000190000,<0.0.7.dev1000200000"
]

[[tool.uv.index]]
name = "testpypi"
url = "https://test.pypi.org/simple/"
publish-url = "https://test.pypi.org/legacy/"
explicit = true

[tool.uv.sources]
uipath-dev = { index = "testpypi" }
```