### PR TITLE
fix: use markdown append for llm chunks

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "uipath-dev"
-version = "0.0.9"
+version = "0.0.10"
 description = "UiPath Developer Console"
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.11"

--- a/src/uipath/dev/ui/panels/chat_panel.py
+++ b/src/uipath/dev/ui/panels/chat_panel.py
@@ -1,6 +1,7 @@
 """Chat panel for displaying and interacting with chat messages."""
 
 import time
+from collections import deque
 
 from textual.app import ComposeResult
 from textual.containers import Container, Vertical, VerticalScroll
@@ -11,6 +12,13 @@ from uipath.core.chat import (
 )
 
 from uipath.dev.models import ChatMessage, ExecutionRun
+
+# Tunables for streaming performance
+STREAM_MIN_INTERVAL = 0.08  # seconds between updates while streaming
+STREAM_MIN_DELTA_CHARS = 8  # min new chars before we bother updating
+
+# Limit how many message widgets we keep mounted to avoid DOM explosion.
+MAX_WIDGETS = 20
 
 
 class Prompt(Markdown):
@@ -36,12 +44,18 @@ class ChatPanel(Container):
 
     _chat_widgets: dict[str, Markdown]
     _last_update_time: dict[str, float]
+    _last_content: dict[str, str]
+    _chat_view: VerticalScroll | None
+    _chat_order: deque[str]
 
     def __init__(self, **kwargs):
         """Initialize the chat panel."""
         super().__init__(**kwargs)
         self._chat_widgets = {}
         self._last_update_time = {}
+        self._last_content = {}
+        self._chat_view = None
+        self._chat_order = deque()
 
     def compose(self) -> ComposeResult:
         """Compose the UI layout."""
@@ -52,12 +66,19 @@ class ChatPanel(Container):
                 id="chat-input",
             )
 
-    def update_messages(self, run: ExecutionRun) -> None:
+    def on_mount(self) -> None:
+        """Called when the panel is mounted."""
+        self._chat_view = self.query_one("#chat-view", VerticalScroll)
+
+    def refresh_messages(self, run: ExecutionRun) -> None:
         """Update the chat panel with messages from the given execution run."""
-        chat_view = self.query_one("#chat-view")
-        chat_view.remove_children()
+        assert self._chat_view is not None
+
+        self._chat_view.remove_children()
         self._chat_widgets.clear()
         self._last_update_time.clear()
+        self._last_content.clear()
+        self._chat_order.clear()
 
         for chat_msg in run.messages:
             self.add_chat_message(
@@ -65,7 +86,8 @@ class ChatPanel(Container):
                 auto_scroll=False,
             )
 
-        chat_view.scroll_end(animate=False)
+        # For a fresh run, always show the latest messages
+        self._chat_view.scroll_end(animate=False)
 
     def add_chat_message(
         self,
@@ -73,12 +95,16 @@ class ChatPanel(Container):
         auto_scroll: bool = True,
     ) -> None:
         """Add or update a chat message bubble."""
-        chat_view = self.query_one("#chat-view")
+        assert self._chat_view is not None
+        chat_view = self._chat_view
+
+        should_autoscroll = auto_scroll and not chat_view.is_vertical_scrollbar_grabbed
 
         message = chat_msg.message
-
         if message is None:
             return
+
+        message_id = message.message_id
 
         widget_cls: type[Prompt] | type[Response] | type[Tool]
         if message.role == "user":
@@ -114,27 +140,82 @@ class ChatPanel(Container):
 
         content = "\n\n".join(content_lines)
 
-        existing = self._chat_widgets.get(message.message_id)
+        prev_content = self._last_content.get(message_id)
+        if prev_content is not None and content == prev_content:
+            # We already rendered this exact content, no need to touch the UI.
+            return
+
+        existing = self._chat_widgets.get(message_id)
         now = time.monotonic()
-        last_update = self._last_update_time.get(message.message_id, 0.0)
+        last_update = self._last_update_time.get(message_id, 0.0)
 
         if existing:
-            event = chat_msg.event
-            should_update = (
-                event
-                and event.exchange
-                and event.exchange.message
-                and event.exchange.message.end is not None
-            )
-            if should_update or now - last_update > 0.15:
+            prev_content_len = len(prev_content) if prev_content is not None else 0
+            delta_len = len(content) - prev_content_len
+
+            def should_update() -> bool:
+                event = chat_msg.event
+                finished = (
+                    event
+                    and event.exchange
+                    and event.exchange.message
+                    and event.exchange.message.end is not None
+                )
+
+                if finished:
+                    # Always paint the final state immediately.
+                    return True
+
+                # Throttle streaming: require both some time and a minimum delta size.
+                if now - last_update < STREAM_MIN_INTERVAL:
+                    return False
+
+                # First streaming chunk for this message: allow update.
+                if prev_content is None:
+                    return True
+
+                if delta_len < STREAM_MIN_DELTA_CHARS:
+                    return False
+
+                return True
+
+            if not should_update():
+                return
+
+            # Fast path: message is growing by appending new text.
+            if (
+                isinstance(existing, Markdown)
+                and prev_content is not None
+                and content.startswith(prev_content)
+            ):
+                delta = content[len(prev_content) :]
+                if delta:
+                    # Streaming update: only append the new portion.
+                    existing.append(delta)
+            else:
+                # Fallback for non-monotonic changes: full update.
                 existing.update(content)
-                self._last_update_time[message.message_id] = now
-                if auto_scroll:
-                    chat_view.scroll_end(animate=False)
+
+            self._last_content[message_id] = content
+            self._last_update_time[message_id] = now
+
         else:
+            # First time we see this message: create a new widget.
             widget_instance = widget_cls(content)
             chat_view.mount(widget_instance)
-            self._chat_widgets[message.message_id] = widget_instance
-            self._last_update_time[message.message_id] = now
-            if auto_scroll:
-                chat_view.scroll_end(animate=False)
+            self._chat_widgets[message_id] = widget_instance
+            self._last_update_time[message_id] = now
+            self._last_content[message_id] = content
+            self._chat_order.append(message_id)
+
+            # Prune oldest widgets to keep DOM size bounded
+            if len(self._chat_order) > MAX_WIDGETS:
+                oldest_id = self._chat_order.popleft()
+                old_widget = self._chat_widgets.pop(oldest_id, None)
+                self._last_update_time.pop(oldest_id, None)
+                self._last_content.pop(oldest_id, None)
+                if old_widget is not None:
+                    old_widget.remove()
+
+        if should_autoscroll:
+            chat_view.scroll_end(animate=False)

--- a/uv.lock
+++ b/uv.lock
@@ -1002,7 +1002,7 @@ wheels = [
 
 [[package]]
 name = "uipath-dev"
-version = "0.0.9"
+version = "0.0.10"
 source = { editable = "." }
 dependencies = [
     { name = "pyperclip" },


### PR DESCRIPTION
## Description

This PR improves streaming performance for LLM chat messages by implementing incremental markdown updates using the `append()` method instead of full re-renders. The key optimization reduces UI latency by only appending new content deltas during streaming rather than updating the entire message on each chunk.

- Implemented markdown append optimization for streaming LLM responses with throttling controls
- Added widget caching in `RunDetailsPanel` to avoid repeated DOM queries
- Introduced widget pruning mechanism to prevent DOM explosion with a 20-widget limit

## Development Package

- Add this package as a dependency in your pyproject.toml:

```toml
[project]
dependencies = [
  # Exact version:
  "uipath-dev==0.0.10.dev1000230062",

  # Any version from PR
  "uipath-dev>=0.0.10.dev1000230000,<0.0.10.dev1000240000"
]

[[tool.uv.index]]
name = "testpypi"
url = "https://test.pypi.org/simple/"
publish-url = "https://test.pypi.org/legacy/"
explicit = true

[tool.uv.sources]
uipath-dev = { index = "testpypi" }
```