### PR TITLE
chore(ci): run the test matrix on uipath- runners

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,15 +6,11 @@ on:
 jobs:
   test:
     name: Test
-    runs-on: ${{ matrix.os == 'windows-latest' && 'uipath-windows-latest' || 'uipath-ubuntu-latest' }}
+    runs-on: ${{ matrix.os }}
     strategy:
       matrix:
         python-version: ["3.11", "3.12", "3.13"]
-        # Stock labels on purpose: GitHub builds the check-run name from these
-        # matrix values, and branch protection requires the stock names
-        # ("Test (3.11, ubuntu-latest)"). runs-on below maps them onto the
-        # uipath- pool, so the jobs run on uipath runners either way.
-        os: [ubuntu-latest, windows-latest]
+        os: [uipath-ubuntu-latest, uipath-windows-latest]
 
     permissions:
       contents: read


### PR DESCRIPTION
## What

Moves the test matrix onto the `uipath-` runner pool:

- `os: [ubuntu-latest, windows-latest]` -> `os: [uipath-ubuntu-latest, uipath-windows-latest]`
- `runs-on` goes back to `${{ matrix.os }}` (the label-mapping expression is no longer needed)

After this, every job in the repo runs on the centralized managed pool.

## Heads-up: required status checks

GitHub builds a matrix job's check-run name from the matrix values, so this renames
the test contexts, e.g.

    test / Test (3.11, ubuntu-latest)   ->   test / Test (3.11, uipath-ubuntu-latest)

The branch ruleset still requires the stock names, so those contexts will sit as
"Expected - waiting for status to be reported" and this PR (and every later PR)
will stay BLOCKED until a repo admin updates the required status checks to the
`uipath-` names.

🤖 Generated with [Claude Code](https://claude.com/claude-code)