### PR TITLE
fix(deps): lower the uipath floor to 2.14.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "uipath-dev"
-version = "0.0.85"
+version = "0.0.86"
 description = "UiPath Developer Console"
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.11"
@@ -10,7 +10,7 @@ dependencies = [
   "pyperclip>=1.11.0, <2.0.0",
   "fastapi>=0.128.8",
   "uvicorn[standard]>=0.40.0",
-  "uipath>=2.14.1, <2.15.0",
+  "uipath>=2.14.0, <2.15.0",
   "aiosqlite>=0.20.0",
   "pywinpty>=2.0.0; sys_platform == 'win32'",
   "mcp[cli]>=1.0.0",

--- a/uv.lock
+++ b/uv.lock
@@ -2593,7 +2593,7 @@ wheels = [
 
 [[package]]
 name = "uipath-dev"
-version = "0.0.85"
+version = "0.0.86"
 source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },
@@ -2633,7 +2633,7 @@ requires-dist = [
     { name = "pyperclip", specifier = ">=1.11.0,<2.0.0" },
     { name = "pywinpty", marker = "sys_platform == 'win32'", specifier = ">=2.0.0" },
     { name = "textual", specifier = ">=7.5.0,<8.0.0" },
-    { name = "uipath", specifier = ">=2.14.1,<2.15.0" },
+    { name = "uipath", specifier = ">=2.14.0,<2.15.0" },
     { name = "uipath-runtime", specifier = ">=0.13.0,<0.14.0" },
     { name = "uvicorn", extras = ["standard"], specifier = ">=0.40.0" },
 ]
@@ -2676,16 +2676,16 @@ wheels = [
 
 [[package]]
 name = "uipath-runtime"
-version = "0.13.0"
+version = "0.13.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "chardet" },
     { name = "uipath-core" },
     { name = "vadersentiment" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/65/c0/d55cf48ee43758c2c1c65f52fd0596fd75f5bd5067a5016e6553b4d2c5fe/uipath_runtime-0.13.0.tar.gz", hash = "sha256:8ae3150df5fb0043210faacf39148789c1fb252c6a8d6bc27174c0d9ce7304f5", size = 243594, upload-time = "2026-08-04T11:19:04.886Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/94/4d/86409493366ee75b5548dd992e5d256ddf304f2b398677169f7f9af7cd99/uipath_runtime-0.13.2.tar.gz", hash = "sha256:004c91a20f85c0a0f61cce30b0dae267f1d8e086476adcbe7e723724e22d1475", size = 246648, upload-time = "2026-08-25T09:31:46.189Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/dc/88/9518dcbeedaa8117e5fd3d0424c4a7354bae1f3ede1b2e3f48524e4b7efc/uipath_runtime-0.13.0-py3-none-any.whl", hash = "sha256:2a7c128cf14fdbef899b272ee5995da63baeb882acc904f39ef8f8f52bcb019f", size = 96349, upload-time = "2026-08-04T11:19:03.376Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/33/f9225df568a3f76c2c5c6e47c9c5043d5e2a9c70a4a83b7450010c337bb0/uipath_runtime-0.13.2-py3-none-any.whl", hash = "sha256:33e4fcd9b6edcc01dfa6e87434a3252319c1f1fd0480a2816d591b763b6e4f86", size = 97014, upload-time = "2026-08-25T09:31:44.692Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Releases `uipath-dev` 0.0.86: 0.0.85's source with the `uipath` floor lowered by one patch.

```diff
-version = "0.0.85"
+version = "0.0.86"
-  "uipath>=2.14.1, <2.15.0",
+  "uipath>=2.14.0, <2.15.0",
```

## Why

0.0.85 is the first release whose `uipath-runtime` range admits 0.13.x, but the same release raised the `uipath` floor to 2.14.1. That leaves a gap: a consumer pinned to `uipath` 2.14.0 has no usable `uipath-dev` at all, because 0.0.84 excludes `uipath-runtime` 0.13.x and 0.0.85 excludes the SDK.

2.14.0 is the release that introduced `uipath-runtime>=0.13.0, <0.14.0` on the SDK side, so nothing in this package requires 2.14.1 specifically. Lowering the floor by one patch closes the gap and keeps the range inside a single minor.

Since `uipath-dev` sits in consumers' dev groups, the gap blocks `uv lock` even though the tool never ships in their wheel.

## Branch

Cut from `b3b1eba`, the commit that built 0.0.85. Base branch `release/uipath-dev-0.0.85` is that same commit. Not for `main`.

## Versioning

0.0.85 is the latest release on the line and 0.0.86 is free, so per the procedure this is a patch increment rather than a post-release.

## Verification

- `uv lock` pinned at `uipath-runtime==0.13.2`
- `uv sync --locked --all-extras` clean
- test suite green, 21 passed

## Publishing

CD is `workflow_dispatch`. Dispatch it against the hotfix branch; the merge into the base branch does not trigger it.