### PR TITLE
ci: do not run cd when a branch is created

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -11,9 +11,11 @@ on:
 
 jobs:
   lint:
+    if: ${{ !github.event.created }}
     uses: ./.github/workflows/lint.yml
 
   test:
+    if: ${{ !github.event.created }}
     uses: ./.github/workflows/test.yml
 
   build:


### PR DESCRIPTION
CD triggers on pushes to `main` and `release/**` filtered to `pyproject.toml`. Creating a `release/*` branch at a commit that touched `pyproject.toml` is a push that can match that filter, so the branch creation itself starts a publish run for a version that was already released.

Today PyPI rejects the duplicate upload, so the run just goes red. It is not harmless in every case: if the base commit's version bump was never actually published, branch creation would publish it from a branch nobody treated as a release.

Gate the CD entry jobs on `!github.event.created`. `build` needs `lint` and `test`, and `pypi-publish` needs `build`, so skipping the two entry jobs skips the chain. Manual `workflow_dispatch` runs are unaffected, since the property is absent there and evaluates as falsy.

Merging a hotfix PR into a release branch is a normal push with commits, so `created` is false and the publish still runs as intended.